### PR TITLE
Align LangList items with the container boundaries

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,6 +56,8 @@ function LangList() {
   const style = {
     display: 'flex',
     flexWrap: 'wrap',
+    // Compensate for LangProgress margins to align the items with the list boundaries.
+    margin: '-1rem',
   }
   return (
     <div style={style}>


### PR DESCRIPTION
Compensate for LangProgress margins to align the items with the list boundaries.

### Before

<img width="805" alt="is_react_translated_yet_before" src="https://user-images.githubusercontent.com/498274/52509805-5f055680-2bae-11e9-84a9-13530438922e.png">

### After

<img width="806" alt="is_react_translated_yet_after" src="https://user-images.githubusercontent.com/498274/52509812-6462a100-2bae-11e9-9439-7cfe31b91269.png">
